### PR TITLE
Added ReflectionUtil - Fixed nearby entities method

### DIFF
--- a/Impl/src/main/java/com/gladurbad/medusa/util/PlayerUtil.java
+++ b/Impl/src/main/java/com/gladurbad/medusa/util/PlayerUtil.java
@@ -19,6 +19,7 @@ import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 
 @UtilityClass
@@ -108,7 +109,7 @@ public class PlayerUtil {
      * @return The entities within that radius
      * @author Nik
      */
-    public List<Entity> getEntitiesWithinRadius(final Location location, final double radius) {
+    public static List<Entity> getEntitiesWithinRadius(final Location location, final double radius) {
 
         final double expander = 16.0D;
 
@@ -123,17 +124,25 @@ public class PlayerUtil {
 
         final World world = location.getWorld();
 
-        List<Entity> entities = new ArrayList<>();
+        List<Entity> entities = new LinkedList<>();
 
         for (int xVal = minX; xVal <= maxX; xVal++) {
+
             for (int zVal = minZ; zVal <= maxZ; zVal++) {
-                if (world.isChunkLoaded(xVal, zVal)) {
-                    entities.addAll(Arrays.asList(world.getChunkAt(xVal, zVal).getEntities()));
+
+                if (!world.isChunkLoaded(xVal, zVal)) continue;
+
+                for (Entity entity : world.getChunkAt(xVal, zVal).getEntities()) {
+                    //We have to do this due to stupidness
+                    if (entity == null) continue;
+
+                    //Make sure the entity is within the radius specified
+                    if (entity.getLocation().distanceSquared(location) > radius * radius) continue;
+
+                    entities.add(entity);
                 }
             }
         }
-
-        entities.removeIf(entity -> entity.getLocation().distanceSquared(location) > radius * radius);
 
         return entities;
     }
@@ -145,6 +154,5 @@ public class PlayerUtil {
 
         return false;
     }
-
 
 }

--- a/Impl/src/main/java/com/gladurbad/medusa/util/PlayerUtil.java
+++ b/Impl/src/main/java/com/gladurbad/medusa/util/PlayerUtil.java
@@ -109,7 +109,7 @@ public class PlayerUtil {
      * @return The entities within that radius
      * @author Nik
      */
-    public static List<Entity> getEntitiesWithinRadius(final Location location, final double radius) {
+    public List<Entity> getEntitiesWithinRadius(final Location location, final double radius) {
 
         final double expander = 16.0D;
 

--- a/Impl/src/main/java/com/gladurbad/medusa/util/ReflectionUtil.java
+++ b/Impl/src/main/java/com/gladurbad/medusa/util/ReflectionUtil.java
@@ -1,0 +1,152 @@
+package main.java.com.gladurbad.medusa.util;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
+import org.bukkit.util.Vector;
+import com.gladurbad.medusa.util.ServerUtil;
+import com.gladurbad.medusa.util.type.BoundingBox;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+@UtilityClass
+public class ReflectionUtil {
+
+    /**
+     * We can make a caching system for this in order to be somewhat more efficient.
+     * Reflection tends to be heavy, especially if we're using it every tick.
+     * Maps would be great!
+     */
+
+    private String versionString;
+
+    public Field getField(Class<?> clazz, String fieldName) {
+        try {
+            return clazz.getField(fieldName);
+        } catch (NoSuchFieldException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public Method getMethod(Class<?> clazz, String methodName, Class<?>... params) {
+        try {
+            return clazz.getMethod(methodName, params);
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public String getVersion() {
+        if (versionString == null) {
+            String name = Bukkit.getServer().getClass().getPackage().getName();
+            versionString = name.substring(name.lastIndexOf('.') + 1) + ".";
+        }
+
+        return versionString;
+    }
+
+    public Class<?> getNMSClass(String nmsClassName) {
+        final String clazzName = "net.minecraft.server." + getVersion() + nmsClassName;
+        try {
+            return Class.forName(clazzName);
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+
+        return null;
+    }
+
+    public Class<?> getOBCClass(String obcClassName) {
+        final String clazzName = "org.bukkit.craftbukkit." + getVersion() + obcClassName;
+        try {
+            return Class.forName(clazzName);
+        } catch (Throwable t) {
+            t.printStackTrace();
+        }
+
+        return null;
+    }
+
+    public static Object craftEntity(Entity entity) {
+        try {
+            return getMethod(getOBCClass("entity.CraftEntity"), "getHandle").invoke(entity);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+
+    public BoundingBox getBoundingBox(Entity entity) {
+        try {
+            final Object nmsBoundingBox = getMethod(getNMSClass("Entity"), "getBoundingBox")
+                    .invoke(craftEntity(entity));
+
+            return toBoundingBox(nmsBoundingBox);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+
+    public BoundingBox toBoundingBox(Object aaBB) {
+
+        final Vector min = getBoxMin(aaBB);
+        final Vector max = getBoxMax(aaBB);
+
+        return new BoundingBox(min, max);
+    }
+
+    private Vector getBoxMin(Object box) {
+
+        double x = 0D;
+        double y = 0D;
+        double z = 0D;
+
+        Class<?> boxClass = box.getClass();
+
+        try {
+            if (!ServerUtil.isHigherThan1_13_2()) {
+                x = (double) getField(boxClass, "a").get(box);
+                y = (double) getField(boxClass, "b").get(box);
+                z = (double) getField(boxClass, "c").get(box);
+            } else {
+                x = (double) getField(boxClass, "minX").get(box);
+                y = (double) getField(boxClass, "minY").get(box);
+                z = (double) getField(boxClass, "minZ").get(box);
+            }
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return new Vector(x, y, z);
+    }
+
+    private Vector getBoxMax(Object box) {
+
+        double x = 0D;
+        double y = 0D;
+        double z = 0D;
+
+        Class<?> boxClass = box.getClass();
+
+        try {
+            if (!ServerUtil.isHigherThan1_13_2()) {
+                x = (double) getField(boxClass, "d").get(box);
+                y = (double) getField(boxClass, "e").get(box);
+                z = (double) getField(boxClass, "f").get(box);
+            } else {
+                x = (double) getField(boxClass, "maxX").get(box);
+                y = (double) getField(boxClass, "maxY").get(box);
+                z = (double) getField(boxClass, "maxZ").get(box);
+            }
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        return new Vector(x, y, z);
+    }
+}

--- a/Impl/src/main/java/com/gladurbad/medusa/util/ServerUtil.java
+++ b/Impl/src/main/java/com/gladurbad/medusa/util/ServerUtil.java
@@ -18,4 +18,8 @@ public class ServerUtil {
     public boolean isLowerThan1_8() {
         return getServerVersion().isLowerThan(ServerVersion.v_1_8);
     }
+
+    public boolean isHigherThan1_13_2() {
+        return getServerVersion().isHigherThan(ServerVersion.v_1_13_2);
+    }
 }

--- a/Impl/src/main/java/com/gladurbad/medusa/util/type/BoundingBox.java
+++ b/Impl/src/main/java/com/gladurbad/medusa/util/type/BoundingBox.java
@@ -6,6 +6,7 @@ import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,6 +39,17 @@ public final class BoundingBox {
             this.minZ = maxZ;
             this.maxZ = minZ;
         }
+    }
+
+    public BoundingBox(final Vector min, final Vector max) {
+
+        this.minX = min.getX();
+        this.minY = min.getY();
+        this.minZ = min.getZ();
+
+        this.maxX = max.getX();
+        this.maxY = max.getY();
+        this.maxZ = max.getZ();
     }
 
     public BoundingBox(final Player player) {


### PR DESCRIPTION
Changelog:

[+] Fixed nearby entities method error due to removeIf's predicate if it encountered a null entity

[+] Added ReflectionUtil

You can now get BoundingBoxes on 1.8-1.16+.
However note that this is not fully functional since in 1.7 there's a different way to get the NMS BoundingBox.

Plus our way is somewhat heavy as it is right now without proper caching.
I wouldn't suggest calling it every tick especially for multiple entities. (Could be fine for just the player)

I apologize for not completely finishing this, But i hope that's a good start.